### PR TITLE
Fix path building

### DIFF
--- a/lib/evil/client.rb
+++ b/lib/evil/client.rb
@@ -122,6 +122,8 @@ module Evil
     end
 
     def method_missing(name, *args, &block)
+      name = name.to_s
+
       if name[PATH_METHOD]
         self[name]
       elsif name[CALL_METHOD]

--- a/spec/integration/path_building_spec.rb
+++ b/spec/integration/path_building_spec.rb
@@ -1,16 +1,18 @@
 describe "remote path building" do
 
-  let(:client) { Evil::Client.with base_url: "http://localhost/v1/" }
-  let(:path)   { client.users[1]["vip-only"] }
+  let(:client)              { Evil::Client.with base_url: "http://localhost/v1/" }
+  let(:users_path)          { client.users }
+  let(:vip_only_users_path) { client.users[1]["vip-only"] }
 
   it "builds absolute uri for API base url" do
-    expect(client.uri!).to   eql "http://localhost/v1/"
-    expect(path.uri!).to     eql "http://localhost/v1/users/1/vip-only"
-    expect(path.sms.uri!).to eql "http://localhost/v1/users/1/vip-only/sms"
+    expect(client.uri!).to                  eql "http://localhost/v1/"
+    expect(users_path.uri!).to              eql "http://localhost/v1/users"
+    expect(vip_only_users_path.uri!).to     eql "http://localhost/v1/users/1/vip-only"
+    expect(vip_only_users_path.sms.uri!).to eql "http://localhost/v1/users/1/vip-only/sms"
   end
 
   it "updates path lazily" do
-    expect(path).to be_kind_of Evil::Client
+    expect(vip_only_users_path).to be_kind_of Evil::Client
   end
 
   it "responds to any method without bang" do


### PR DESCRIPTION
Проблема была в следующем. При вызове у клиента метода типа `PATH_METHOD`, выставлялась переменная `@path` не как тип `String`, а как тип `Symbol`. При последующем вызове метода `uri!` у клиента, выражение `URI.join("#{base_url}/", path)` падало с ошибкой.

``` ruby
client = Evil::Client.with base_url: 'http://example.com'
client.foo
#<Evil::Client:0x007fc6dd248af0 @path=#<Evil::Client::Path:0x007fc6dd248a50 @path=:foo>, @api=#<Evil::Client::API:0x007fc6dd2524b0 @base_url="http://example.com">>
client.foo.uri!
ArgumentError: bad argument (expected URI object or URI string)
```
