### PR TITLE
Allow to pass response handling to parent scopes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Style/Alias:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/DateTime:
+  Enabled: false
+
 Style/FileName:
   Exclude:
     - lib/evil-client.rb

--- a/evil-client.gemspec
+++ b/evil-client.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = "~> 2.3"
 
   gem.add_runtime_dependency "dry-initializer", "~> 2.1"
-  gem.add_runtime_dependency "tram-policy", "~> 0.2.2"
   gem.add_runtime_dependency "mime-types", "~> 3.1"
   gem.add_runtime_dependency "rack", "~> 2"
+  gem.add_runtime_dependency "tram-policy", "~> 0.2.2"
 
   gem.add_development_dependency "rake", ">= 10"
   gem.add_development_dependency "rspec", "~> 3.0"

--- a/lib/evil/client.rb
+++ b/lib/evil/client.rb
@@ -61,12 +61,8 @@ module Evil
       # Sets a custom connection, or resets it to a default one
       #
       # @param  [#call, nil] connection
-      # @return [self]
       #
-      def connection=(connection)
-        @connection = connection
-        self
-      end
+      attr_writer :connection
 
       # Schema for the root scope of the client
       #
@@ -108,7 +104,6 @@ module Evil
     #
     def logger=(logger)
       @scope.logger = logger
-      self
     end
 
     # Operations defined at the root of the client

--- a/lib/evil/client/model.rb
+++ b/lib/evil/client/model.rb
@@ -104,7 +104,7 @@ class Evil::Client
       def new(op = {})
         op = Hash(op).each_with_object({}) { |(k, v), obj| obj[k.to_sym] = v }
         super(op).tap { |item| in_english { policy[item].validate! } }
-      rescue => error
+      rescue StandardError => error
         raise ValidationError, error.message
       end
       alias call new

--- a/lib/evil/client/resolver.rb
+++ b/lib/evil/client/resolver.rb
@@ -46,7 +46,7 @@ class Evil::Client
       yield.tap do |obj|
         logger&.debug(self.class) { "resolved #{self} to #{obj.inspect}" }
       end
-    rescue => err
+    rescue StandardError => err
       logger&.error(self.class) { "failed to resolve #{self}: #{err.message}" }
       raise
     end

--- a/lib/evil/client/resolver/query.rb
+++ b/lib/evil/client/resolver/query.rb
@@ -31,7 +31,7 @@ class Evil::Client
 
       left  = __stringify_keys__(left)
       right = __stringify_keys__(right)
-      right.keys.each { |key| left[key] = __deep_merge__ left[key], right[key] }
+      right.each_key { |key| left[key] = __deep_merge__ left[key], right[key] }
 
       left
     end

--- a/lib/evil/client/resolver/response.rb
+++ b/lib/evil/client/resolver/response.rb
@@ -6,6 +6,9 @@ class Evil::Client
   class Resolver::Response < Resolver
     private
 
+    PROCESSING_DONE = Object.new
+    SKIP_RESPONSE   = Object.new
+
     def initialize(schema, settings, response)
       @__response__ = Array response
       super schema, settings, :responses, @__response__.first.to_i
@@ -13,14 +16,20 @@ class Evil::Client
 
     def __call__
       super do
-        __check_status__
-        instance_exec(*@__response__, &__blocks__.last)
+        catch(PROCESSING_DONE) do
+          __blocks__.reverse_each do |block|
+            catch(SKIP_RESPONSE) do
+              throw(PROCESSING_DONE, instance_exec(*@__response__, &block))
+            end
+          end
+          # We're here if 1) no blocks or 2) all blocks skipped processing
+          raise ResponseError.new(@__schema__, @__settings__, @__response__)
+        end
       end
     end
 
-    def __check_status__
-      return if __blocks__.any?
-      raise ResponseError.new(@__schema__, @__settings__, @__response__)
+    def super!
+      throw SKIP_RESPONSE
     end
   end
 end

--- a/lib/evil/client/resolver/uri.rb
+++ b/lib/evil/client/resolver/uri.rb
@@ -20,7 +20,7 @@ class Evil::Client
 
     def __uri__(path)
       URI path
-    rescue => error
+    rescue StandardError => error
       raise __definition_error__(error.message)
     end
 

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Evil::Client::Settings do
   end
 
   describe "#datetime" do
-    let(:time) { DateTime.parse "2017-07-21 16:58:00 UTC" }
+    let(:time) { Time.parse "2017-07-21 16:58:00 UTC" }
     subject { settings.datetime value }
 
     context "with a parceable string" do


### PR DESCRIPTION
For example to allow to handle specific cases in operation handlers and common cases – in parent scopes.

The only method I found to implement this without changing API is to use `throw` and `catch` (very rarely used in Ruby) with unique constants to avoid any chance of collision.