### PR TITLE
fix name error base 64

### DIFF
--- a/lib/evil/client.rb
+++ b/lib/evil/client.rb
@@ -10,6 +10,7 @@ require "delegate"
 require "tram-policy"
 require "net/http"
 require "net/https"
+require "base64"
 #
 # Namespace for gems created by Evil Martians
 #


### PR DESCRIPTION
Hi, I'm fixed the following error when running `evil-client`
```
NameError: uninitialized constant Evil::Client::Resolver::Security::Base64
from ....../evil-client-3.0.2/lib/evil/client/resolver/security.rb:27:in `basic_auth'
```