### PR TITLE
Don't remove ActiveSupport::Dependencies::Loadable methods

### DIFF
--- a/lib/evil/client/names.rb
+++ b/lib/evil/client/names.rb
@@ -47,6 +47,10 @@ class Evil::Client
       to_s
       to_str
       token_auth
+      load_dependency
+      unloadable
+      require_or_load
+      require_dependency
     ].freeze
 
     # Matches whether a name can be used in operations/scopes/options


### PR DESCRIPTION
Fixes work with bootsnap >= 1.3

As Brick Top said: "You're on thin fucking ice"