### PR TITLE
Add public_send to protected instance methods

### DIFF
--- a/lib/evil/client/names.rb
+++ b/lib/evil/client/names.rb
@@ -36,6 +36,7 @@ class Evil::Client
       operation
       operations
       options
+      public_send
       schema
       scope
       scopes


### PR DESCRIPTION
Unfortunately one crucial method that makes code less buggy was missed in this Names module that cleans odd methods. `public_send` removes the confusing of "whether this is a private or public method?"