### PR TITLE
Don't remove public_send method from Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres
 to [Semantic Versioning].
 
+## [3.0.5] [2022-20-01]
+
+### Fixed
+- Don't remove public_send method from Scope (@mrexox)
+
 ## [3.0.4] [2019-07-10]
 
 ### Added

--- a/lib/evil/client/names.rb
+++ b/lib/evil/client/names.rb
@@ -36,6 +36,7 @@ class Evil::Client
       operation
       operations
       options
+      public_send
       schema
       scope
       scopes


### PR DESCRIPTION
Unfortunately one crucial method that makes code less buggy was missed in this Names module that cleans odd methods. `public_send` removes the confusing of "whether this is a private or public method?"