### PR TITLE
Add ruby 3+ support.

### DIFF
--- a/evil-client.gemspec
+++ b/evil-client.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files       = gem.files.grep(/^spec/)
   gem.extra_rdoc_files = Dir["README.md", "LICENSE", "CHANGELOG.md"]
 
-  gem.required_ruby_version = "~> 2.3"
+  gem.required_ruby_version = ">= 2.3"
 
   gem.add_runtime_dependency "dry-initializer", ">= 2.1", "< 4"
   gem.add_runtime_dependency "mime-types", "~> 3.1"

--- a/lib/evil/client.rb
+++ b/lib/evil/client.rb
@@ -78,8 +78,8 @@ module Evil
         schema.respond_to? name
       end
 
-      def method_missing(*args, &block)
-        respond_to_missing?(*args) ? schema.send(*args, &block) : super
+      def method_missing(*args, **kwargs, &block)
+        respond_to_missing?(*args) ? schema.send(*args, **kwargs, &block) : super
       end
     end
 
@@ -152,7 +152,7 @@ module Evil
     private
 
     def initialize(**options)
-      @scope = Container::Scope.new self.class.send(:schema), options
+      @scope = Container::Scope.new self.class.send(:schema), **options
     end
   end
 end

--- a/lib/evil/client/builder/operation.rb
+++ b/lib/evil/client/builder/operation.rb
@@ -23,7 +23,7 @@ class Evil::Client
     # @return [Evil::Client::Container::Operation]
     #
     def new(**options)
-      Container::Operation.new schema, parent.options.merge(options)
+      Container::Operation.new schema, **parent.options.merge(options)
     end
 
     # @!method call(options)

--- a/lib/evil/client/builder/scope.rb
+++ b/lib/evil/client/builder/scope.rb
@@ -23,7 +23,7 @@ class Evil::Client
     # @return [Evil::Client::Container::Scope]
     #
     def new(**options)
-      Container::Scope.new schema, parent.options.merge(options)
+      Container::Scope.new schema, **parent.options.merge(options)
     end
     alias_method :call, :new
     alias_method :[],   :new

--- a/lib/evil/client/chaining.rb
+++ b/lib/evil/client/chaining.rb
@@ -11,10 +11,10 @@ class Evil::Client
       operations[name] || scopes[name]
     end
 
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args, **kwargs, &block)
       return super unless respond_to_missing? name
 
-      (operations[name] || scopes[name]).call(*args)
+      (operations[name] || scopes[name]).call(*args, **kwargs)
     end
   end
 end

--- a/lib/evil/client/container.rb
+++ b/lib/evil/client/container.rb
@@ -74,7 +74,7 @@ class Evil::Client
 
     def initialize(schema, logger = nil, **opts)
       @schema   = schema
-      @settings = schema.settings.new(logger, opts)
+      @settings = schema.settings.new(logger, **opts)
     end
   end
 end

--- a/lib/evil/client/formatter.rb
+++ b/lib/evil/client/formatter.rb
@@ -22,7 +22,7 @@ class Evil::Client
       return to_form(source) if format == :form
       return to_text(source) if format == :text
 
-      to_multipart(source, opts)
+      to_multipart(source, **opts)
     end
 
     private
@@ -43,8 +43,8 @@ class Evil::Client
       Form.call source
     end
 
-    def to_multipart(source, opts)
-      Multipart.call [source], opts
+    def to_multipart(source, **opts)
+      Multipart.call [source], **opts
     end
   end
 end

--- a/lib/evil/client/model.rb
+++ b/lib/evil/client/model.rb
@@ -91,9 +91,9 @@ class Evil::Client
       # @param  [Hash] op Model options
       # @return [Evil::Client::Model]
       #
-      def new(op = {})
+      def new(**op)
         op = Hash(op).each_with_object({}) { |(k, v), obj| obj[k.to_sym] = v }
-        super(op).tap { |item| in_english { policy[item].validate! } }
+        super(**op).tap { |item| in_english { policy[item].validate! } }
       end
       alias call new
       alias []   call
@@ -116,7 +116,7 @@ class Evil::Client
 
       def extend_model(other)
         other.dry_initializer.options.each do |definition|
-          option definition.source, definition.options
+          option definition.source, **definition.options
         end
 
         other.lets.each { |key, block| let(key, &block) }

--- a/lib/evil/client/settings.rb
+++ b/lib/evil/client/settings.rb
@@ -50,9 +50,9 @@ class Evil::Client
       # @param  [Hash<#to_sym, Object>, nil] opts
       # @return [Evil::Client::Settings]
       #
-      def new(logger, op = {})
+      def new(logger, **op)
         logger&.debug(self) { "initializing with options #{op}..." }
-        super(op).tap do |item|
+        super(**op).tap do |item|
           item.logger = logger
           logger&.debug(item) { "initialized" }
         end

--- a/spec/features/custom_connection_spec.rb
+++ b/spec/features/custom_connection_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "custom connection" do
   let(:conn)     { double call: response }
   let(:response) { [200, { "Foo" => "Bar" }, ["Hello!"]] }
   let(:params)   { { subdomain: "europe", user: "andy", token: "foo" } }
-  let(:users)    { Test::Client.new(params).crm(version: 4).users }
+  let(:users)    { Test::Client.new(**params).crm(version: 4).users }
 
   before do
     load "spec/fixtures/test_client.rb"

--- a/spec/features/operation/options_spec.rb
+++ b/spec/features/operation/options_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "operation options" do
   before { load "spec/fixtures/test_client.rb" }
 
   let(:params) { { subdomain: "europe", user: "andy", token: "foo", foo: 0 } }
-  let(:users)  { Test::Client.new(params).crm(version: 4).users }
+  let(:users)  { Test::Client.new(**params).crm(version: 4).users }
 
   shared_examples :valid_client do |details = "properly"|
     it "[assigns operation options #{details}]" do

--- a/spec/features/scope/options_spec.rb
+++ b/spec/features/scope/options_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "scope options" do
   before { load "spec/fixtures/test_client.rb" }
 
   let(:params) { { subdomain: "europe", user: "andy", token: "foo", foo: 0 } }
-  let(:client) { Test::Client.new(params) }
+  let(:client) { Test::Client.new(**params) }
   let(:crm)    { client.crm(version: 4) }
 
   shared_examples :valid_client do |details = "properly"|

--- a/spec/unit/builder/operation_spec.rb
+++ b/spec/unit/builder/operation_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Evil::Client::Builder::Operation do
   end
 
   describe "#new" do
-    subject { builder.new options }
+    subject { builder.new **options }
 
     it "creates operation with inherited options accepted by settings" do
       expect(subject).to be_a Evil::Client::Container::Operation
@@ -66,7 +66,7 @@ RSpec.describe Evil::Client::Builder::Operation do
     let(:operation) { double call: "success" }
 
     before  { allow(builder).to receive(:new) { operation } }
-    subject { builder.call options }
+    subject { builder.call **options }
 
     it "builds and calls the operation at once" do
       expect(builder).to receive(:new).with options
@@ -79,7 +79,7 @@ RSpec.describe Evil::Client::Builder::Operation do
     let(:operation) { double call: "success" }
 
     before  { allow(builder).to receive(:new) { operation } }
-    subject { builder[options] }
+    subject { builder[**options] }
 
     it "is an alias for #call" do
       expect(builder).to receive(:new).with options

--- a/spec/unit/builder/scope_spec.rb
+++ b/spec/unit/builder/scope_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Evil::Client::Builder::Scope do
   end
 
   describe "#new" do
-    subject { builder.new options }
+    subject { builder.new **options }
 
     it "creates scope with inherited options accepted by settings" do
       expect(subject).to be_a Evil::Client::Container::Scope
@@ -63,7 +63,7 @@ RSpec.describe Evil::Client::Builder::Scope do
   end
 
   describe "#call" do
-    subject { builder.call options }
+    subject { builder.call **options }
 
     it "creates scope with inherited options accepted by settings" do
       expect(subject).to be_a Evil::Client::Container::Scope
@@ -73,7 +73,7 @@ RSpec.describe Evil::Client::Builder::Scope do
   end
 
   describe "#[]" do
-    subject { builder[options] }
+    subject { builder[**options] }
 
     it "creates scope with inherited options accepted by settings" do
       expect(subject).to be_a Evil::Client::Container::Scope

--- a/spec/unit/container/operation_spec.rb
+++ b/spec/unit/container/operation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Evil::Client::Container::Operation do
     end
   end
 
-  let(:operation)  { described_class.new schema, nil, opts }
+  let(:operation)  { described_class.new(schema, nil, **opts) }
   let(:connection) { Evil::Client::Connection }
   let(:schema) do
     double :schema,

--- a/spec/unit/container/scope_spec.rb
+++ b/spec/unit/container/scope_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Evil::Client::Container::Scope do
-  let(:scope)  { described_class.new schema, nil, opts }
+  let(:scope)  { described_class.new schema, nil, **opts }
   let(:opts) { { token: "qux", id: 7, language: "en_US", name: "Joe", age: 9 } }
   let(:update_schema) { double :update_schema, name: :update }
   let(:admins_schema) { double :admins_schema, name: :admins }

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Evil::Client::Container do
   let(:klass)     { double :class }
-  let(:container) { described_class.new schema, logger, opts }
+  let(:container) { described_class.new schema, logger, **opts }
   let(:logger)    { Logger.new log }
   let(:log)       { StringIO.new }
   let(:opts) do

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Evil::Client::Model do
   before { class Test::Model < described_class; end }
 
-  let(:model)    { klass.new(options) }
+  let(:model)    { klass.new(**options) }
   let(:klass)    { Test::Model }
   let(:options)  { { "id" => 42, "name" => "Andrew" } }
   let(:dsl_methods) do

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Evil::Client::Settings do
-  let(:settings) { klass.new(logger, options) }
+  let(:settings) { klass.new(logger, **options) }
   let(:log)      { StringIO.new }
   let(:logger)   { Logger.new log }
   let(:schema)   { double :schema, to_s: "Test::Api.users.update" }


### PR DESCRIPTION
Whats done?
- updated max ruby version
- updated tram-policy version 
- fixed some kwargs errors.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

As for tram-policy, I only run rspec locally on my 3.1.2