### PR TITLE
Make specs green in both ruby 2.6 and ruby 3.

### DIFF
--- a/lib/evil/client/schema.rb
+++ b/lib/evil/client/schema.rb
@@ -84,7 +84,7 @@ class Evil::Client
     # @param  (see Evil::Client::Model.validate)
     # @return [self]
     #
-    def validate(&block)
+    def validate(*_args, &block)
       settings.validate(&block)
       self
     end

--- a/lib/evil/client/schema/operation.rb
+++ b/lib/evil/client/schema/operation.rb
@@ -158,7 +158,7 @@ class Evil::Client
     # @param  [Proc] block
     # @return [self]
     #
-    def response(*codes, &block)
+    def response(*codes, **_kwargs, &block)
       codes.flatten.map(&:to_i).each do |code|
         definitions[:responses][code] = block || proc { |*response| response }
       end

--- a/lib/evil/client/schema/scope.rb
+++ b/lib/evil/client/schema/scope.rb
@@ -20,7 +20,7 @@ class Evil::Client
     #
     # @return [Hash<Symbol, Class>]
     #
-    def scopes
+    def scopes(*_args)
       @__children__.reject { |_, child| child.leaf? }
     end
 
@@ -28,7 +28,7 @@ class Evil::Client
     #
     # @return [Hash<[Symbol, nil], Class>]
     #
-    def operations
+    def operations(*_args)
       @__children__.select { |_, child| child.leaf? }
     end
 
@@ -38,7 +38,7 @@ class Evil::Client
     # @param  [Proc] block The block containing definition for the subscope
     # @return [self]
     #
-    def scope(name, &block)
+    def scope(name, **_kwargs, &block)
       key = NameError.check!(name)
       TypeError.check! self, key, :scope
       @__children__[key] ||= self.class.new(self, key)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Evil::Client do
     subject { klass.scopes }
 
     it "returns subscopes from the root schema" do
-      expect(subject).to eq(klass.schema.scopes(nil))
+      expect(subject).to eq klass.schema.scopes
     end
   end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Evil::Client do
     subject { klass.scopes }
 
     it "returns subscopes from the root schema" do
-      expect(subject).to eq klass.schema.scopes
+      expect(subject).to eq(klass.schema.scopes(nil))
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe Evil::Client do
     subject { klass.scope(:users) {} }
 
     it "updates root schema scopes" do
-      expect(klass.schema).to receive(:scope).with :users
+      expect(klass.schema).to receive(:scope).with(:users, any_args)
 
       subject
     end
@@ -54,7 +54,7 @@ RSpec.describe Evil::Client do
     subject { klass.operation(:users) {} }
 
     it "updates root schema scopes" do
-      expect(klass.schema).to receive(:operation).with :users
+      expect(klass.schema).to receive(:operation).with(:users, any_args)
 
       subject
     end

--- a/spec/unit/model_spec.rb
+++ b/spec/unit/model_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Evil::Client::Model do
 
   let(:model)    { klass.new(**options) }
   let(:klass)    { Test::Model }
-  let(:options)  { { "id" => 42, "name" => "Andrew" } }
+  let(:options)  { { id: 42, name: "Andrew" } }
   let(:dsl_methods) do
     %i[options datetime logger scope basic_auth key_auth token_auth]
   end
@@ -64,7 +64,7 @@ RSpec.describe Evil::Client::Model do
       klass.validate { errors.add :name_present if name.to_s == "" }
     end
 
-    let(:options) { { "name" => "" } }
+    let(:options) { { name: "" } }
 
     it "adds validation for an instance" do
       # see spec/fixtures/locale/en.yml

--- a/spec/unit/settings_spec.rb
+++ b/spec/unit/settings_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Evil::Client::Settings do
   let(:logger)   { Logger.new log }
   let(:schema)   { double :schema, to_s: "Test::Api.users.update" }
   let(:klass)    { described_class.for(schema) }
-  let(:options)  { { "id" => 42, "name" => "Andrew" } }
+  let(:options)  { { id: 42, name: "Andrew" } }
   let(:dsl_methods) do
     %i[options datetime logger scope basic_auth key_auth token_auth]
   end
@@ -93,7 +93,7 @@ RSpec.describe Evil::Client::Settings do
       klass.validate { errors.add :name_present if name.to_s == "" }
     end
 
-    let(:options) { { "name" => "" } }
+    let(:options) { { name: "" } }
 
     it "adds validation for an instance" do
       # see spec/fixtures/locale/en.yml


### PR DESCRIPTION
Ok, although it looks tricky, I've managed to make green specs on both 2.6 and 3.1.2