### PR TITLE
Fix RSpec definition

### DIFF
--- a/lib/evil/client/rspec.rb
+++ b/lib/evil/client/rspec.rb
@@ -1,25 +1,27 @@
-class Evil::Client
-  #
-  # Collection of RSpec-related definitions
-  #
-  module RSpec
-    require_relative "rspec/evil_client_schema_matching"
-    require_relative "rspec/base_stub"
-    require_relative "rspec/allow_stub"
-    require_relative "rspec/expect_stub"
+module Evil
+  class Client
+    #
+    # Collection of RSpec-related definitions
+    #
+    module RSpec
+      require_relative "rspec/evil_client_schema_matching"
+      require_relative "rspec/base_stub"
+      require_relative "rspec/allow_stub"
+      require_relative "rspec/expect_stub"
 
-    def stub_client_operation(klass = Evil::Client, name = nil)
-      AllowStub.new(klass, name)
-    end
+      def stub_client_operation(klass = Evil::Client, name = nil)
+        AllowStub.new(klass, name)
+      end
 
-    def expect_client_operation(klass, name = nil)
-      ExpectStub.new(klass, name)
-    end
+      def expect_client_operation(klass, name = nil)
+        ExpectStub.new(klass, name)
+      end
 
-    def unstub_all
-      allow(Evil::Client::Container::Operation)
-        .to receive(:new)
-        .and_call_original
+      def unstub_all
+        allow(Evil::Client::Container::Operation)
+          .to receive(:new)
+          .and_call_original
+      end
     end
   end
 end


### PR DESCRIPTION
In case we try to repeat [this example](https://evilclient.readthedocs.io/en/latest/rspec/) from the docs, we receive this error

```
Failure/Error: require "evil/client/rspec"

NameError:
  uninitialized constant Evil
# /usr/local/bundle/gems/evil-client-3.2.0/lib/evil/client/rspec.rb:1:in `<top (required)>'
# ./spec/lib/cats_client_spec.rb:1:in `<top (required)>'
```

These changes fix that issue