### PR TITLE
Stop referencing removed Rack::VERSION

### DIFF
--- a/lib/evil/client/resolver/request.rb
+++ b/lib/evil/client/resolver/request.rb
@@ -35,7 +35,7 @@ class Evil::Client
         "SERVER_NAME" => uri.host,
         "SERVER_PORT" => uri.port,
         "HTTP_Variables" => headers,
-        "rack.version" => Rack::VERSION,
+        "rack.version" => Rack.release,
         "rack.url_scheme" => uri.scheme,
         "rack.input" => Formatter.call(body, format, boundary: boundary),
         "rack.multithread" => false,

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Evil::Client::Connection, ".call" do
         "Authorization" => "Bearer eoiqopr==",
         "Content-Type" => "application/json"
       },
-      "rack.version" => Rack::VERSION,
+      "rack.version" => Rack.release,
       "rack.input" => "name=Andrew&age=46",
       "rack.url_scheme" => "https",
       "rack.multithread" => false,

--- a/spec/unit/resolver/request_spec.rb
+++ b/spec/unit/resolver/request_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Evil::Client::Resolver::Request, ".call" do
         "Authorization" => "Bearer eoiqopr==",
         "Content-Type" => "application/json"
       },
-      "rack.version" => Rack::VERSION,
+      "rack.version" => Rack.release,
       "rack.input" => '{"version":"v77"}',
       "rack.url_scheme" => "https",
       "rack.multithread" => false,


### PR DESCRIPTION
`Rack::VERSION` was [removed](https://github.com/rack/rack/blob/main/CHANGELOG.md#310---2024-06-11) in Rack version 3.1.0. 

This PR changes all references to `Rack::VERSION` to `Rack.release`.