### PR TITLE
fix: remove base64 from dependencies

### DIFF
--- a/evil-client.gemspec
+++ b/evil-client.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.6"
 
-  gem.add_runtime_dependency "base64", ">= 0.2.0", "< 0.3"
   gem.add_runtime_dependency "dry-initializer", ">= 2.1"
   gem.add_runtime_dependency "mime-types", ">= 3.1"
   gem.add_runtime_dependency "rack", ">= 2"

--- a/lib/evil/client/resolver/security.rb
+++ b/lib/evil/client/resolver/security.rb
@@ -1,3 +1,5 @@
+require "base64"
+
 class Evil::Client
   #
   # Resolves security definitions from operation settings and schema.


### PR DESCRIPTION
**:wrench: Summary**

Actually base64 is included in Ruby 3.4, but it requires a `require "base64"` now
